### PR TITLE
:recycle: Add restify-errors for error reporting

### DIFF
--- a/package.json
+++ b/package.json
@@ -30,6 +30,7 @@
     "morgan": "^1.9.1",
     "restify": "^8.4.0",
     "restify-cors-middleware": "^1.1.1",
+    "restify-errors": "^8.0.1",
     "restify-jwt-community": "^1.1.0",
     "saslprep": "^1.0.3",
     "winston": "^3.2.1"

--- a/src/api/components/auth/auth.controller.js
+++ b/src/api/components/auth/auth.controller.js
@@ -1,4 +1,5 @@
 import bcrypt from 'bcrypt';
+import { UnauthorizedError, InternalServerError } from 'restify-errors';
 
 import Jwt from '../../../lib/Jwt.lib';
 
@@ -11,7 +12,7 @@ const login = async ({ body: { password } }, res) => {
     const { user } = res.locals;
     const match = await bcrypt.compare(password, user.password);
 
-    if (!match) return res.send(401, { error: 'Senha inválida' });
+    if (!match) res.send(new UnauthorizedError('Senha inválida'));
 
     const jwt = Jwt.encode({ name: user.name });
 
@@ -19,7 +20,7 @@ const login = async ({ body: { password } }, res) => {
 
     return res.send(200, { jwt });
   } catch (error) {
-    return res.send(500, error);
+    return res.send(new InternalServerError({ cause: error }));
   }
 };
 

--- a/src/api/components/auth/auth.middleware.js
+++ b/src/api/components/auth/auth.middleware.js
@@ -1,8 +1,10 @@
+import { BadRequestError, UnauthorizedError } from 'restify-errors';
+
 import User from '../user/user.model';
 
 const hasBody = (req, res, next) => {
   if (!req.body) {
-    return res.send(400, { error: 'Usuário não foi informado' });
+    return res.send(new BadRequestError('Usuário não foi informado'));
   }
 
   return next();
@@ -13,7 +15,7 @@ const loadUser = async (req, res, next) => {
   const user = await User.findOne({ email }).select('+password');
 
   if (!user) {
-    return res.send(401, { error: 'Email não cadastrado' });
+    return res.send(new UnauthorizedError('Email não cadastrado'));
   }
 
   res.locals = { user };

--- a/src/api/components/user/user.controller.js
+++ b/src/api/components/user/user.controller.js
@@ -1,3 +1,5 @@
+import { InternalServerError } from 'restify-errors';
+
 import User from './user.model';
 
 const getAll = async (req, res) => {
@@ -6,7 +8,7 @@ const getAll = async (req, res) => {
 
     return res.send(200, users);
   } catch (error) {
-    return res.send(500, error);
+    return res.send(new InternalServerError({ cause: error }));
   }
 };
 
@@ -18,7 +20,7 @@ const save = async ({ body }, res) => {
 
     return res.send(201, user);
   } catch (error) {
-    return res.send(500, error);
+    return res.send(new InternalServerError({ cause: error }));
   }
 };
 

--- a/test/controllers/auth.test.js
+++ b/test/controllers/auth.test.js
@@ -51,7 +51,7 @@ describe(path, () => {
         });
 
       expect(status).to.equal(401);
-      expect(body).to.have.property('error');
+      expect(body).to.have.property('message');
     });
 
     it('should return status 200 with valid user and login', async () => {

--- a/test/controllers/auth.test.js
+++ b/test/controllers/auth.test.js
@@ -30,7 +30,7 @@ describe(path, () => {
       const { status, body } = await request(server).post(path);
 
       expect(status).to.equal(400);
-      expect(body).to.have.property('error');
+      expect(body).to.have.property('message');
     });
 
     it('should return status 401 and JSON error when email does not exist', async () => {
@@ -39,7 +39,7 @@ describe(path, () => {
         .send({ email: 'marco@gmail.com', password: 'ah98sh98sa89s' });
 
       expect(status).to.equal(401);
-      expect(body).to.have.property('error');
+      expect(body).to.have.property('message');
     });
 
     it('should return status 401 and JSON error when the not equal password', async () => {


### PR DESCRIPTION
Closes #8 

Changed middlewares and controllers from both **user** and **auth**  so they use `restify-errors` for error reporting.

#### Note

I had to change the tests to ensure a `message` field was set, instead of the previous `error` field, since `restify-errors` sends the message on a `message` field.